### PR TITLE
Мелкие фиксы №4

### DIFF
--- a/stripper/ze_palace_adventure_v1_2.cfg
+++ b/stripper/ze_palace_adventure_v1_2.cfg
@@ -1,0 +1,15 @@
+; Stripper by RedSnip
+; Исправляет конфликт каналов геймтекста
+
+modify:
+{
+	match:
+	{
+		"targetname" "timer_text"
+		"classname" "game_text"
+	}
+	replace:
+	{
+		"channel" "4"
+	}
+}

--- a/stripper/ze_paradise_v2_csgo.cfg
+++ b/stripper/ze_paradise_v2_csgo.cfg
@@ -1,0 +1,14 @@
+; Stripper by RedSnip
+; Звук закрытия двери не накладывается сам на себя
+
+modify:
+{
+	match:
+	{
+		"targetname" "rockdoor"
+	}
+	replace:
+	{
+		"loopmovesound" "0"
+	}
+}

--- a/stripper/ze_ramp_a1_1.cfg
+++ b/stripper/ze_ramp_a1_1.cfg
@@ -1,0 +1,28 @@
+; Stripper by RedSnip
+; Исправляет конфликт каналов геймтекста
+
+modify:
+{
+	match:
+	{
+		"targetname" "text_sec"
+		"classname" "game_text"
+	}
+	replace:
+	{
+		"channel" "4"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"targetname" "text_seconds_left"
+		"classname" "game_text"
+	}
+	replace:
+	{
+		"channel" "5"
+	}
+}

--- a/stripper/ze_undersea_temple_a2.cfg
+++ b/stripper/ze_undersea_temple_a2.cfg
@@ -1,0 +1,28 @@
+; Stripper by RedSnip
+; Исправляет конфликт каналов геймтекста
+
+modify:
+{
+	match:
+	{
+		"targetname" "text_sec"
+		"classname" "game_text"
+	}
+	replace:
+	{
+		"channel" "4"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"targetname" "text_seconds_left"
+		"classname" "game_text"
+	}
+	replace:
+	{
+		"channel" "5"
+	}
+}


### PR DESCRIPTION
Исправил конфликт каналов геймтекста на картах: ze_palace_adventure_v1_2, ze_ramp_a1_1, ze_undersea_temple_a2
Удалил наложение звука двери на карте ze_paradise_v2_csgo