### PR TITLE
удаление секретной кнопки ze_shroomforest2_p6

### DIFF
--- a/stripper/ze_shroomforest2_p6.cfg
+++ b/stripper/ze_shroomforest2_p6.cfg
@@ -401,6 +401,14 @@ modify:
 	}
 }
 
+;отключает секретную кнопку, которая телепортировала игрока за пределы карты.
+filter:
+{
+	"targetname" "DoritoBut"
+	"classname" "func_button"
+	"hammerid" "1446991"
+}
+
 ;авторство
 modify:
 {


### PR DESCRIPTION
отключает секретную кнопку, которая телепортировала игрока за пределы карты