### PR TITLE
+ ze_UT2004_Convoy_r5.cfg

### DIFF
--- a/stripper/ze_UT2004_Convoy_r5.cfg
+++ b/stripper/ze_UT2004_Convoy_r5.cfg
@@ -1,0 +1,19 @@
+;Убирает кастомные модели игроков, которые вызывали сильный дроп фпс у игроков
+filter:
+{
+	"targetname" "SetPlayerModel_Human"
+}
+filter:
+{
+	"targetname" "MZMTimer"
+}
+
+;Убрана баганная громкая музыка по просьбе большинства игроков
+filter:
+{
+	"classname" "env_soundscape_triggerable"
+}
+filter:
+{
+	"classname" "trigger_soundscape"
+}


### PR DESCRIPTION
Убирает баганную музыку и кастомные модели игроков, что вызывали дроп фпс.